### PR TITLE
Fix to pdb stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Documentation: [https://BioPandas.github.io/biopandas/](https://BioPandas.github.io/biopandas/)
 - Source code repository: [https://github.com/rasbt/biopandas](https://github.com/rasbt/biopandas)
 - PyPI: [https://pypi.python.org/pypi/biopandas](https://pypi.python.org/pypi/biopandas)
-- How to contribute: [https://BioPandas.github.io/biopandas//contributing/](https://BioPandas.github.io/biopandas/contributing/)
+- How to contribute: [https://biopandas.github.io/biopandas/CONTRIBUTING/](https://biopandas.github.io/biopandas/CONTRIBUTING/)
 - Changelog: [./docs/sources/CHANGELOG.md](./docs/sources/CHANGELOG.md)
 
 <br>

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -66,7 +66,7 @@ class PandasPdb(object):
 
     @property
     def df(self):
-        """Acccess dictionary of pandas DataFrames for PDB record sections."""
+        """Access dictionary of pandas DataFrames for PDB record sections."""
         return self._df
 
     @df.setter
@@ -115,22 +115,25 @@ class PandasPdb(object):
         self.header, self.code = self._parse_header_code()
         return self
 
-
     def fetch_pdb(self, pdb_code: Optional[str] = None, uniprot_id: Optional[str] = None, source: str = "pdb"):
-        """Fetches PDB file contents from the Protein Databank at rcsb.org or AlphaFold database at https://alphafold.ebi.ac.uk/.
+        """Fetches PDB file contents from the Protein Databank at rcsb.org or AlphaFold database
+        at https://alphafold.ebi.ac.uk/.
 .
 
         Parameters
         ----------
         pdb_code : str, optional
-            A 4-letter PDB code, e.g., `"3eiy"` to retrieve structures from the PDB. Defaults to `None`.
+            A 4-letter PDB code, e.g., `"3eiy"` to retrieve structures from the PDB.
+            Defaults to `None`.
 
         uniprot_id : str, optional
-            A UniProt Identifier, e.g., `"Q5VSL9"` to retrieve structures from the AF2 database. Defaults to `None`.
+            A UniProt Identifier, e.g., `"Q5VSL9"` to retrieve structures from the AF2 database.
+            Defaults to `None`.
 
         source : str
             The source to retrieve the structure from 
-            (`"pdb"`, `"alphafold2-v1"`, `"alphafold2-v2"`, `"alphafold2-v3"` (latest)). Defaults to `"pdb"`.
+            (`"pdb"`, `"alphafold2-v1"`, `"alphafold2-v2"`, `"alphafold2-v3"` (latest)).
+            Defaults to `"pdb"`.
 
         Returns
         ---------
@@ -144,13 +147,12 @@ class PandasPdb(object):
         invalid_input_combination_2 = pdb_code is not None and source in {
             "alphafold2-v1", "alphafold2-v2", "alphafold2-v3"}
 
-
         if invalid_input_identifier_1 or invalid_input_identifier_2:
             raise ValueError("Please provide either a PDB code or a UniProt ID.")
 
-        if invalid_input_combination_1 :
+        if invalid_input_combination_1:
             raise ValueError("Please use a 'pdb_code' instead of 'uniprot_id' for source='pdb'.")
-        elif invalid_input_combination_2 :
+        elif invalid_input_combination_2:
             raise ValueError(f"Please use a 'uniprot_id' instead of 'pdb_code' for source={source}.")
 
         if source == "alphafold2-v1":
@@ -364,7 +366,6 @@ class PandasPdb(object):
             print('URL Error %s' % e.args)
         return url, txt
 
-
     def _parse_header_code(self):
         """Extract header information and PDB code."""
         code, header = "", ""
@@ -441,7 +442,7 @@ class PandasPdb(object):
                     record = line[:6].rstrip()
                     line_ele = ["" for _ in range(len(pdb_records[record]) + 1)]
                     for idx, ele in enumerate(pdb_records[record]):
-                        line_ele[idx] = line[ele["line"][0] : ele["line"][1]].strip()
+                        line_ele[idx] = line[ele["line"][0]: ele["line"][1]].strip()
                     line_ele[-1] = line_num
                     line_lists[record].append(line_ele)
                 else:
@@ -486,7 +487,7 @@ class PandasPdb(object):
         Parameters
         ----------
         record : str, default: 'ATOM'
-            Specfies the record DataFrame.
+            Specifies the record DataFrame.
         residue_col : str,  default: 'residue_name'
             Column in `record` DataFrame to look for 3-letter amino acid
             codes for the conversion.
@@ -786,8 +787,8 @@ class PandasPdb(object):
 
         Parameters
         ----------
-        model_index : int
-            An integer representing the model index to subset to.
+        model_indices : List[int]
+            A list representing the model indexes to subset to.
 
         Returns
         ---------
@@ -812,14 +813,14 @@ class PandasPdb(object):
             ]
         return df
 
-    def to_pdb_stream(self, records: List[str] = ["ATOM", "HETATM"]) -> StringIO:
+    def to_pdb_stream(self, records: tuple[str] = ("ATOM", "HETATM")) -> StringIO:
         """Writes a PDB dataframe to a stream.
 
         Parameters
         ------------
-        records : List[str]
-            List of record names to save to stream. Any of `["ATOM", "HETATM", "OTHERS"]`.
-        
+        records : iterable, default: ('ATOM', 'HETATM')
+            Iterable of record names to save to stream. Any of `["ATOM", "HETATM", "OTHERS"]`.
+
         Returns
         --------
         io.StringIO : Filestream of PDB file.
@@ -861,4 +862,5 @@ class PandasPdb(object):
         to_write = "\n".join(s)
         output.write(to_write)
         output.write("\n")
-        return output.seek(0)
+        output.seek(0)
+        return output

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,21 @@ The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md).
 
 
+### 0.5.1 (26-03-2023)
+
+##### Downloads
+
+- [Source code (zip)](https://github.com/rasbt/biopandas/archive/v0.5.1.zip)
+- [Source code (tar.gz)](https://github.com/rasbt/biopandas/archive/v0.5.1.tar.gz)
+
+##### Bug Fixes
+
+- Fix the `return` statement in `PandasPdb.to_pdb_stream()` to return `output` instead of `output.seek(0)`. (via [goniochromatic](https://github.com/github.com/goniochromatic/), PR #[116](https://github.com/rasbt/biopandas/pull/116/files))
+- Change the `records` default argument in `PandasPdb.to_pdb_stream()` to be immutable. (via [goniochromatic](https://github.com/github.com/goniochromatic/), PR #[116](https://github.com/rasbt/biopandas/pull/116/files))
+- Fix some typos and general style issues. (via [goniochromatic](https://github.com/github.com/goniochromatic/), PR #[116](https://github.com/rasbt/biopandas/pull/116/files))
+- Fix link for "How to contribute" in `README.md`. (via [goniochromatic](https://github.com/github.com/goniochromatic/), PR #[116](https://github.com/rasbt/biopandas/pull/116/files))
+
+
 ### 0.5.0dev (UNRELEASED)
 
 


### PR DESCRIPTION
### Description

<!--  
Please insert a brief description of the Pull request below.
-->
Fixed the bug where PandasPdb.to_pdb_stream() was returning `output.seek(0)` instead of `output`, and the default argument for the `records` parameter in the same function was changed from a mutable to an immutable object, as general best practice.

Fixed some general typos and style issues in pandas_pdb.py, and also updated the link to "How to contribute" in `README.md`

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->
issue [#108](https://github.com/BioPandas/biopandas/issues/108)

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
