### PR TITLE
Add support for pathlib

### DIFF
--- a/biopandas/mmcif/pandas_mmcif.py
+++ b/biopandas/mmcif/pandas_mmcif.py
@@ -55,7 +55,7 @@ class PandasMmcif:
 
         Attributes
         ----------
-        path : str
+        path : Union[str, os.PathLike]
             Path to the MMCIF file in .cif format or gzipped format (.cif.gz).
 
         Returns
@@ -63,7 +63,7 @@ class PandasMmcif:
         self
 
         """
-        self.mmcif_path, self.pdb_text = self._read_mmcif(path=path)
+        self.mmcif_path, self.pdb_text = self._read_mmcif(path=str(path))
         self._df = self._construct_df(text=self.pdb_text)
         # self.header, self.code = self._parse_header_code() #TODO: implement
         self.code = self.data["entry"]["id"][0].lower()

--- a/biopandas/mmcif/tests/test_read_mmcif.py
+++ b/biopandas/mmcif/tests/test_read_mmcif.py
@@ -8,6 +8,7 @@
 import os
 from urllib.error import HTTPError
 from urllib.request import urlopen
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -259,6 +260,15 @@ def test_read_pdb_from_list():
         assert ppdb.pdb_text == pdb_text
         assert ppdb.code == code
         assert ppdb.mmcif_path == ""
+
+
+def test_read_pdb_with_pathlib():
+    """Test public read_pdb with pathlib.Path object as input"""
+    ppdb = PandasMmcif()
+    ppdb.read_mmcif(Path(TESTDATA_FILENAME))
+    assert ppdb.pdb_text == three_eiy
+    assert ppdb.code == "3eiy", ppdb.code
+    assert ppdb.mmcif_path == TESTDATA_FILENAME
 
 
 # Again, not sure how ANISOU are handled, so skipping

--- a/biopandas/mmtf/pandas_mmtf.py
+++ b/biopandas/mmtf/pandas_mmtf.py
@@ -1,6 +1,7 @@
 """Class for working with MMTF files."""
 from __future__ import annotations
 
+import os
 import copy
 import gzip
 import warnings
@@ -44,7 +45,8 @@ class PandasMmtf(object):
         )
         # self._df = value
 
-    def read_mmtf(self, filename: str):
+    def read_mmtf(self, filename: Union[str, os.PathLike]):
+        filename = str(filename)
         if filename.endswith(".gz"):
             self.mmtf = parse_gzip(filename)
         else:

--- a/biopandas/mmtf/tests/test_multiple_models.py
+++ b/biopandas/mmtf/tests/test_multiple_models.py
@@ -39,3 +39,6 @@ def test_get_models():
     # Note: No way to preserve model ID as far as I can tell
     assert_frame_equal(df.df["ATOM"].drop("model_id", axis=1).reset_index(drop=True), written.df["ATOM"].drop("model_id", axis=1).reset_index(drop=True))
     assert_frame_equal(df.df["HETATM"].drop("model_id", axis=1).reset_index(drop=True), written.df["HETATM"].drop("model_id", axis=1).reset_index(drop=True))
+
+    # Clean
+    os.remove("test.mmtf")

--- a/biopandas/mmtf/tests/test_write_mmtf.py
+++ b/biopandas/mmtf/tests/test_write_mmtf.py
@@ -18,6 +18,8 @@ def test_write_mmtf_bp():
         assert_frame_equal(pm1.df["ATOM"].reset_index(drop=True), pm2.df["ATOM"].reset_index(drop=True))
         assert_frame_equal(pm1.df["HETATM"].reset_index(drop=True), pm2.df["HETATM"].reset_index(drop=True))
 
+    os.remove("test.mmtf")
+
 def test_write_mmtf():
     PDB_CODES = ["4hhb", "3eiy", "1t48", "1ehz", "4ggb", "1bxa", "1cbn", "1rcf"]
     for pdb in PDB_CODES:
@@ -29,4 +31,6 @@ def test_write_mmtf():
         pm2 = PandasMmtf().read_mmtf("test.mmtf")
         assert_frame_equal(pm1.df["ATOM"].reset_index(drop=True), pm2.df["ATOM"].reset_index(drop=True))
         assert_frame_equal(pm1.df["HETATM"].reset_index(drop=True), pm2.df["HETATM"].reset_index(drop=True))
+
+    os.remove("test.mmtf")
 

--- a/biopandas/mol2/pandas_mol2.py
+++ b/biopandas/mol2/pandas_mol2.py
@@ -96,7 +96,7 @@ class PandasMol2(object):
 
         Attributes
         ----------
-        path : str
+        path : Union[str, os.PathLike]
             Path to the Mol2 file in .mol2 format or gzipped format (.mol2.gz)
 
         columns : dict or None (default: None)
@@ -118,7 +118,7 @@ class PandasMol2(object):
         self
 
         """
-        mol2_code, mol2_lines = next(split_multimol2(path))
+        mol2_code, mol2_lines = next(split_multimol2(str(path)))
         self._load_mol2(mol2_lines, mol2_code, columns)
         self.mol2_path = path
         return self

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -91,7 +91,7 @@ class PandasPdb(object):
         self
 
         """
-        self.pdb_path, self.pdb_text = self._read_pdb(path=path)
+        self.pdb_path, self.pdb_text = self._read_pdb(path=str(path))
         self._df = self._construct_df(pdb_lines=self.pdb_text.splitlines(True))
         self.header, self.code = self._parse_header_code()
         return self

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -42,7 +42,7 @@ class PandasPdb(object):
     pdb_text : str
         PDB file contents in raw text format.
 
-    pdb_path : str
+    pdb_path : Union[str, os.PathLike]
         Location of the PDB file that was read in via `read_pdb`
         or URL of the page where the PDB content was fetched from
         if `fetch_pdb` was called.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,10 @@ The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md).
 
 
-### 0.5.0dev1 (11/4/2023)
+### 0.5.0dev1 (24/5/2023)
 
-- Adds supprt for reading Gzipped MMTF files. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))
+- Adds support for pathlib. (Via [Anton Bushuiev](https://github.com/anton-bushuiev), PR #[128](https://github.com/BioPandas/biopandas/pull/128))
+- Adds support for reading Gzipped MMTF files. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))
 - Improves reliability of parsing polymer/non-polymer entities in MMTF parsing. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))
 - Improves reliability of parsing multicharacter chain IDs from MMTF files. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))
 - Replaces null terminator chars in parsed MMTF dataframe with the empty string. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))


### PR DESCRIPTION

```
from pathlib import Path
path = Path('/kaggle/input/6nzk.pdb')


ppdb_df =  PandasPdb().read_pdb(path)
  303 """Read PDB file from local drive."""
  304 r_mode = "r"
--> 305 if path.endswith((".pdb", ".ent")):
  306     openf = open
  307 elif path.endswith(("pdb.gz", ".ent.gz")):

AttributeError: 'PosixPath' object has no attribute 'endswith'
```

### Code of Conduct

<!-- 
If this is your first Pull Request for the BioPandas repository, please review
the code of conduct, which is available at http://rasbt.github.io/biopandas/CODE_OF_CONDUCT/. 
-->


### Description

<!--  
Please insert a brief description of the Pull request below.
-->

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
