### PR TITLE
b_factor one white space format fix

### DIFF
--- a/biopandas/pdb/engines.py
+++ b/biopandas/pdb/engines.py
@@ -116,7 +116,7 @@ pdb_atomdict = [
         "id": "b_factor",
         "line": [60, 66],
         "type": float,
-        "strf": lambda x: ("%+6.2f" % x).replace("+", " "),
+        "strf": lambda x: ("%+6.2f" % x).replace("+", " ") if len(str(int(x))) < 3 else ("%+6.2f" % x).replace("+", ""),
     },
     {"id": "blank_4", "line": [66, 72], "type": str, "strf": lambda x: "%-7s" % x},
     {"id": "segment_id", "line": [72, 76], "type": str, "strf": lambda x: "%-3s" % x},

--- a/biopandas/pdb/tests/test_write_pdb.py
+++ b/biopandas/pdb/tests/test_write_pdb.py
@@ -71,3 +71,14 @@ def test_anisou():
         f1 = f.read()
     os.remove(OUTFILE)
     assert f1 == four_eiy
+
+
+def test_b_factor_shift():
+    """Test b_factor shifting one white space when saving the fetched pdb."""
+    ppdb = PandasPdb()
+    ppdb.fetch_pdb("2e28")
+    ppdb.to_pdb(path=OUTFILE, records=None)
+    tmp_df = ppdb.read_pdb(path=OUTFILE).df['ATOM']
+    os.remove(OUTFILE)
+    assert tmp_df[tmp_df["element_symbol"].isnull() | (tmp_df["element_symbol"] == '')].empty
+    assert not tmp_df[tmp_df["blank_4"].isnull() | (tmp_df["blank_4"] == '')].empty

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ The CHANGELOG for the current development version is available at
 
 ### 0.5.0dev1 (24/5/2023)
 
+- B_factor shifting one white space issue fix. (Via [Zehra Sarica](https://github.com/zehraacarsarica), PR #[134](https://github.com/BioPandas/biopandas/pull/134))
 - Adds support for pathlib. (Via [Anton Bushuiev](https://github.com/anton-bushuiev), PR #[128](https://github.com/BioPandas/biopandas/pull/128))
 - Adds support for reading Gzipped MMTF files. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))
 - Improves reliability of parsing polymer/non-polymer entities in MMTF parsing. (Via [Arian Jamasb](https://github.com/a-r-j), PR #[123](https://github.com/rasbt/biopandas/pull/123/files))


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the BioPandas repository, please review
the code of conduct, which is available at http://rasbt.github.io/biopandas/CODE_OF_CONDUCT/. 
-->


### Description

<!--  
Please insert a brief description of the Pull request below.
-->

### Related issues or pull requests
#133
<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
